### PR TITLE
Fixing `Params#to_h` error when running without Rails

### DIFF
--- a/lib/scheemer/extensions/string.rb
+++ b/lib/scheemer/extensions/string.rb
@@ -3,10 +3,35 @@
 module Scheemer
   module Extensions
     module CaseModifier
+      CAMELCASER = lambda do |value|
+        first, *rest = value.to_s.split("_")
+        [first, rest.collect(&:capitalize)].join
+      end
+      UNDERSCORER = lambda do |value|
+        value.gsub(/::/, '/').
+          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+          tr("-", "_").
+          downcase
+      end
+
       refine Symbol do
         def camelcase
-          first, *rest = to_s.split("_")
-          [first, rest.collect(&:capitalize)].join.to_sym
+          CAMELCASER.(self).to_sym
+        end
+
+        def underscore
+          UNDERSCORER.(self).to_sym
+        end
+      end
+
+      refine String do
+        def camelcase
+          CAMELCASER.(self)
+        end
+
+        def underscore
+          UNDERSCORER.(self)
         end
       end
     end


### PR DESCRIPTION
Previously calling `to_h` without having ActiveSupport Extensions loaded would yield in an error.

```ruby
Params.new({...}).to_h # => Undefined method "underscore"
```